### PR TITLE
[LOPS-1775] Fix machine name when syncing secrets.

### DIFF
--- a/pantheon_secrets.services.yml
+++ b/pantheon_secrets.services.yml
@@ -3,3 +3,4 @@ services:
     class: Drupal\pantheon_secrets\SecretsSyncer\SecretsSyncer
     arguments:
       - '@entity_type.manager'
+      - '@transliteration'

--- a/src/SecretsSyncer/SecretsSyncer.php
+++ b/src/SecretsSyncer/SecretsSyncer.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\pantheon_secrets\SecretsSyncer;
 
+use Drupal\Component\Transliteration\TransliterationInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use PantheonSystems\CustomerSecrets\CustomerSecrets;
 use PantheonSystems\CustomerSecrets\CustomerSecretsClientInterface;
-use Drupal\Component\Transliteration\TransliterationInterface;
 
 /**
  * Sync secrets from Pantheon to key entities.

--- a/src/SecretsSyncer/SecretsSyncer.php
+++ b/src/SecretsSyncer/SecretsSyncer.php
@@ -51,7 +51,7 @@ class SecretsSyncer implements SecretsSyncerInterface {
    * Get machine name for a given key.
    */
   protected function getMachineName(string $secretName): string {
-    $transliterated = $this->transliteration->transliterate($secretName);
+    $transliterated = $this->transliteration->transliterate(strtolower($secretName));
     $transliterated = preg_replace('@[^a-z0-9_.]+@', '_', $transliterated);
     return $transliterated;
   }


### PR DESCRIPTION
This was causing that editing a synced secret with an invalid machine name was erroring out.

With this change, the secret will get a correct machine name preventing this error.