### PR TITLE
[LOPS-2160] Support base64 encoded secrets.

### DIFF
--- a/src/Plugin/KeyProvider/PantheonSecretKeyProvider.php
+++ b/src/Plugin/KeyProvider/PantheonSecretKeyProvider.php
@@ -47,6 +47,7 @@ class PantheonSecretKeyProvider extends KeyProviderBase implements KeyPluginForm
   public function defaultConfiguration() {
     return [
       'secret_name' => '',
+      'base64_encoded' => false,
     ];
   }
 
@@ -72,6 +73,13 @@ class PantheonSecretKeyProvider extends KeyProviderBase implements KeyPluginForm
         '#default_value' => $this->maskSecretValue($this->secretsClient->getSecret($secret_name)->getValue()),
       ];
     }
+
+    $form['base64_encoded'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Base64 encoded'),
+      '#description' => $this->t('Check this box if the secret is base64 encoded.'),
+      '#default_value' => $this->getConfiguration()['base64_encoded'],
+    ];
 
     return $form;
   }
@@ -143,8 +151,12 @@ class PantheonSecretKeyProvider extends KeyProviderBase implements KeyPluginForm
       return NULL;
     }
 
-    return $secret->getValue();
+    $value = $secret->getValue();
+    if ($this->configuration['base64_encoded']) {
+      $value = base64_decode($value);
+    }
 
+    return $value;
   }
 
   /**


### PR DESCRIPTION
A key generated with `dd` contains non-readable chars so it's usually base64 encoded before storing it anywhere (including Secrets service as per the original issue); however, Pantheon Secrets wasn't handling the base64 decoding when getting the secret value. Added new option to secrets to select whether they're base64 encoded or not.

Original issue: https://www.drupal.org/project/pantheon_secrets/issues/3425767